### PR TITLE
Sync documentation style

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 # Crossterm Style
 
-This crate allows you to work with the terminal cursor. It supports all UNIX and Windows terminals down
-to Windows 7 (not all terminals are tested, see the
+This crate allows you to work with the terminal colors and text attributes. It supports all UNIX
+and Windows terminals down to Windows 7 (not all terminals are tested, see the
 [Tested Terminals](https://github.com/crossterm-rs/crossterm/blob/master/README.md#tested-terminals) for more info).
 
 `crossterm_style` is a sub-crate of the [crossterm](https://crates.io/crates/crossterm) crate. You can use it

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Issues in this repository are disabled for the same reason. Please, report all i
     - Bold, italic, underscore and crossed word
     - [More attributes](https://crossterm-rs.github.io/crossterm/docs/styling.html#attributes) (Windows 10 and UNIX only)
 
-## Getting started
+## Getting Started
 
 <details>
 <summary>
@@ -83,7 +83,7 @@ println!("{}", styled_text);
 let styled_text = style("Bold Underlined").with(Color::Red).on(Color::Blue);
 ```
 
-### RGB colors & ANSI values
+### RGB Colors and ANSI Values
 
 ```rust
 use crossterm::{Colored, Color, Colorize};
@@ -99,7 +99,7 @@ println!("{} some colored text", Colored::Fg(Color::Rgb {
 println!("{} some colored text", Colored::Fg(Color::AnsiValue(10)));
 ```
 
-## Other resources
+## Other Resources
 
 - [API documentation](https://docs.rs/crossterm_style/) (with other examples)
 - [Examples repository](https://github.com/crossterm-rs/examples)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # Crossterm Style
 
-This crate allows you to style the terminal cross-platform. 
-It supports all UNIX and windows terminals down to windows 7 (not all terminals are tested see
-[Tested Terminals](#tested-terminals) for more info)
+This crate allows you to work with the terminal cursor. It supports all UNIX and Windows terminals down
+to Windows 7 (not all terminals are tested, see the
+[Tested Terminals](https://github.com/crossterm-rs/crossterm/blob/master/README.md#tested-terminals) for more info).
 
 `crossterm_style` is a sub-crate of the [crossterm](https://crates.io/crates/crossterm) crate. You can use it
 directly, but it's **highly recommended** to use the [crossterm](https://crates.io/crates/crossterm) crate with
@@ -19,62 +19,42 @@ for more info).
 
 Issues in this repository are disabled for the same reason. Please, report all issues in the
 [crossterm-rs/crossterm](https://github.com/crossterm-rs/crossterm/issues) repository.
- 
-## Table of contents:
-- [Getting started](#getting-started)
-- [Useful links](#useful-links)
-- [Features](#features)
-- [Examples](#examples)
-- [Tested Terminals](#tested-terminals)
-- [Authors](#authors)
-- [License](#license)
-
-## Getting Started
-
-All examples of how `crossterm_style` works can be found in the [examples](https://github.com/crossterm-rs/examples)
-repository. Add the `crossterm_style` package to your `Cargo.toml` file.
-
-```
-[dependencies]
-crossterm_style = "0.5"
-```
-
-And import the `crossterm_style` modules you want to use.
-
-```rust  
-pub use crossterm_style::{color, style, Attribute, Color, ObjectStyle, StyledObject, TerminalColor, Colorize, Styler};
-```
-
-### Useful Links
-
-- [Documentation](https://docs.rs/crossterm_input/)
-- [Crates.io](https://crates.io/crates/crossterm_input)
-- [Book](https://crossterm-rs.github.io/crossterm/docs/styling.html)
-- [Examples](https://github.com/crossterm-rs/examples)
 
 ## Features
 
-These are the features of this crate:
-
 - Cross-platform
 - Multi-threaded (send, sync)
-- Detailed Documentation
-- Few Dependencies
+- Detailed documentation
+- Few dependencies
 - Styled output
-    - Foreground Color (16 base colors)
-    - Background Color (16 base colors)
-    - 256 (ANSI) Color Support (Windows 10 and UNIX Only)
-    - RGB Color Support (Windows 10 and UNIX only)
-    - Text Attributes: bold, italic, underscore and crossed word and [more](https://crossterm-rs.github.io/crossterm/docs/styling.html#attributes) (Windows 10 and UNIX only)
+  - Foreground color (16 base colors)
+  - Background color (16 base colors)
+  - 256 (ANSI) color support (Windows 10 and UNIX only)
+  - RGB color support (Windows 10 and UNIX only)
+  - Text attributes
+    - Bold, italic, underscore and crossed word
+    - [More attributes](https://crossterm-rs.github.io/crossterm/docs/styling.html#attributes) (Windows 10 and UNIX only)
 
-## Examples
+## Getting started
 
-The [examples](https://github.com/crossterm-rs/examples) repository has more complete and verbose examples.
+<details>
+<summary>
+Click to show Cargo.toml.
+</summary>
 
-_style text with attributes_
+```toml
+[dependencies]
+# All crossterm features are enabled by default.
+crossterm = "0.11"
+```
+
+</details>
+<p></p>
+
+### Attributes
 
 ```rust
-use crossterm_style::{Colored, Color, Colorize, Styler, Attribute};
+use crossterm::{Colored, Color, Colorize, Styler, Attribute};
 
 // pass any `Attribute` value to the formatting braces.
 println!("{} Underlined {} No Underline", Attribute::Underlined, Attribute::NoUnderline);
@@ -87,10 +67,10 @@ println!("{}", styled_text);
 let styled_text = style("Bold Underlined").bold().underlined();
 ```
 
-_style text with colors_
+### Colors
 
 ```rust
-use crossterm_style::{Colored, Color, Colorize};
+use crossterm::{Colored, Color, Colorize};
 
 println!("{} Red foreground color", Colored::Fg(Color::Red));
 println!("{} Blue background color", Colored::Bg(Color::Blue));
@@ -103,9 +83,11 @@ println!("{}", styled_text);
 let styled_text = style("Bold Underlined").with(Color::Red).on(Color::Blue);
 ```
 
-_style text with RGB and ANSI Value_
+### RGB colors & ANSI values
 
 ```rust
+use crossterm::{Colored, Color, Colorize};
+
 // custom rgb value (Windows 10 and UNIX systems)
 println!("{} some colored text", Colored::Fg(Color::Rgb {
     r: 10,
@@ -117,21 +99,11 @@ println!("{} some colored text", Colored::Fg(Color::Rgb {
 println!("{} some colored text", Colored::Fg(Color::AnsiValue(10)));
 ```
 
-## Tested terminals
+## Other resources
 
-- Windows Powershell
-    - Windows 10 (pro)
-- Windows CMD
-    - Windows 10 (pro)
-    - Windows 8.1 (N)
-- Ubuntu Desktop Terminal
-    - Ubuntu 17.10
-- (Arch, Manjaro) KDE Konsole
-- Linux Mint
-
-This crate supports all Unix terminals and windows terminals down to Windows 7 but not all of them have been tested.
-If you have used this library for a terminal other than the above list without issues feel free to add it
-to the above list, I really would appreciate it.
+- [API documentation](https://docs.rs/crossterm_style/) (with other examples)
+- [Examples repository](https://github.com/crossterm-rs/examples)
+- [The Book](https://crossterm-rs.github.io/crossterm/docs/index.html)
 
 ## Authors
 
@@ -139,7 +111,7 @@ to the above list, I really would appreciate it.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE.md](./LICENSE) file for details
+This project is licensed under the MIT License - see the [LICENSE](./LICENSE) file for details
 
 [s1]: https://img.shields.io/crates/v/crossterm_style.svg
 [l1]: https://crates.io/crates/crossterm_style

--- a/src/enums/attribute.rs
+++ b/src/enums/attribute.rs
@@ -7,7 +7,7 @@ use crate::SetAttr;
 
 /// Represents a text attribute.
 ///
-/// # Platform-specific notes
+/// # Platform-specific Notes
 ///
 /// * Only UNIX and Windows 10 terminals do support text attributes.
 /// * Keep in mind that not all terminals support all attributes.

--- a/src/enums/attribute.rs
+++ b/src/enums/attribute.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::SetAttr;
 
-/// Represents a text attribute.
+/// Represents an attribute.
 ///
 /// # Platform-specific Notes
 ///

--- a/src/enums/attribute.rs
+++ b/src/enums/attribute.rs
@@ -5,17 +5,36 @@ use serde::{Deserialize, Serialize};
 
 use crate::SetAttr;
 
-/// Enum with the different attributes to style your test.
+/// Represents a text attribute.
 ///
-/// There are few things to note:
-/// - Not all attributes are supported, some of them are only supported on Windows some only on Unix,
-/// and some are only very rarely supported.
-/// - I got those attributes, descriptions, supportability from here: https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
-/// - Take note of the fact that when running your program cross-platform that some attributes might not work because of their support.
-/// - When an attribute is not supported nothing will happen with the terminal state.
+/// # Platform-specific notes
 ///
-/// # Example
-/// You can use an attribute in a write statement to apply the attribute to the terminal output.
+/// * Only UNIX and Windows 10 terminals do support text attributes.
+/// * Keep in mind that not all terminals support all attributes.
+/// * Crossterm implements almost all attributes listed in the
+///   [SGR parameters](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters).
+///
+/// | Attribute | Windows | Unix | Notes |
+/// | :-- | :--: | :--: | :-- |
+/// | `Reset` | ✓ | ✓ | |
+/// | `Bold` | ✓ | ✓ | |
+/// | `Dim` | ✓ | ✓ | |
+/// | `Italic` | ? | ? | Not widely supported, sometimes treated as inverse. |
+/// | `Underlined` | ✓ | ✓ | |
+/// | `SlowBlink` | ? | ? | Not widely supported, sometimes treated as inverse. |
+/// | `RapidBlink` | ? | ? | Not widely supported. MS-DOS ANSI.SYS; 150+ per minute. |
+/// | `Reverse` | ✓ | ✓ | |
+/// | `Hidden` | ✓ | ✓ | Also known as Conceal. |
+/// | `Fraktur` | ✗ | ✓ | Legible characters, but marked for deletion. |
+/// | `DefaultForegroundColor` | ? | ? | Implementation specific (according to standard). |
+/// | `DefaultBackgroundColor` | ? | ? | Implementation specific (according to standard). |
+/// | `Framed` | ? | ? | Not widely supported. |
+/// | `Encircled` | ? | ? | This should turn on the encircled attribute. |
+/// | `OverLined` | ? | ? | This should draw a line at the top of the text. |
+///
+/// # Examples
+///
+/// Basic usage:
 ///
 /// ```no_run
 /// use crossterm_style::Attribute;
@@ -27,7 +46,8 @@ use crate::SetAttr;
 /// );
 /// ```
 ///
-/// You can also call attribute functions on a `&'static str`:
+/// Style existing text:
+///
 /// ```no_run
 /// use crossterm_style::Styler;
 ///
@@ -38,104 +58,55 @@ use crate::SetAttr;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub enum Attribute {
-    /// All attributes off
-    /// [info]: This will reset all current set attributes.
-    /// [Supportability]: Windows, UNIX.
+    /// Resets all the attributes.
     Reset = 0,
-    /// Increased Intensity
-    /// [info]: This will increase the text sensitivity also known as bold.
-    /// [Supportability]: Windows, UNIX.
+    /// Increases the text intensity.
     Bold = 1,
-    /// Decreased Intensity
-    /// [info]: This will decrease the text sensitivity also known as bold.
-    /// [Supportability]: Windows, UNIX.
+    /// Decreases the text intensity.
     Dim = 2,
-    /// Italic Text
-    /// [info]: This will make the text italic.
-    /// [Supportability]: Not widely supported, sometimes treated as inverse.
+    /// Emphasises the text.
     Italic = 3,
-    /// This will draw a line under the text.
-    /// [info]: An line under a word, especially in order to show its importance.
-    /// [Supportability]: Windows, UNIX
+    /// Underlines the text.
     Underlined = 4,
-    /// Slow Blinking Text
-    /// [info]: Blink Less than 150 per minute.
-    /// [Supportability]: UNIX
+    /// Makes the text blinking (< 150 per minute).
     SlowBlink = 5,
-    /// Slow Blinking Text
-    /// [info]: MS-DOS ANSI.SYS; 150+ per minute;
-    /// [Supportability]: Not widely supported
+    /// Makes the text blinking (>= 150 per minute).
     RapidBlink = 6,
-    /// Swap foreground and background colors
-    /// [info]: swap foreground and background colors
-    /// [Supportability]: Windows, UNIX
+    /// Swaps foreground and background colors.
     Reverse = 7,
-    /// Hide text
-    /// [info]:
-    /// - This will make the text hidden.
-    /// - Also known as 'Conceal'
-    /// [Supportability]: Windows, UNIX
+    /// Hides the text (also known as Conceal).
     Hidden = 8,
-    /// Cross-out text
-    /// [info]: Characters legible, but marked for deletion.
-    /// [Supportability]: UNIX
+    /// Crosses the text.
     CrossedOut = 9,
-    /// The Fraktur is a typeface belonging to the group of Gothic typefaces.
-    /// [info]: https://nl.wikipedia.org/wiki/Fraktur
-    /// [Supportability]: Rarely supported
+    /// Sets the [Fraktur](https://en.wikipedia.org/wiki/Fraktur) typeface.
+    ///
+    /// Mostly used for [mathematical alphanumeric symbols](https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols).
     Fraktur = 20,
-    /// This will turn off the bold attribute.
-    /// [info]:
-    /// - Double-underline per ECMA-48.
-    /// - WikiPedia: https://en.wikipedia.org/wiki/Talk:ANSI_escape_code#SGR_21%E2%80%94%60Bold_off%60_not_widely_supported
-    /// - Opposite of `Bold`(1)
-    /// [Supportability]: not widely supported
+    /// Turns off the `Bold` attribute.
     NoBold = 21,
-    /// Normal color or intensity
-    /// Neither bold nor faint
+    /// Switches the text back to normal intensity (no bold, italic).
     NormalIntensity = 22,
-    /// This will turn off the italic attribute.
-    /// [info]:
-    /// - Not italic, not Fraktur
-    /// - Opposite of `Italic`(3)
-    /// [Supportability]: Windows, UNIX
+    /// Turns off the `Italic` attribute.
     NoItalic = 23,
-    /// This will turn off the underline attribute.
-    /// [info]:
-    /// - Not singly or doubly underlined will be turned off.
-    /// - Opposite of `Underlined.`(4)
-    /// [Supportability]: Windows, UNIX
+    /// Turns off the `Underlined` attribute.
     NoUnderline = 24,
-    /// This will turn off the blinking attribute
-    /// [info]: Opposite of `Slow and Rapid blink.`(5,6)
-    /// [Supportability]: Unknown
+    /// Turns off the text blinking (`SlowBlink` or `RapidBlink`).
     NoBlink = 25,
-    /// This will turn off the reverse attribute.
-    /// [info]: Opposite of `Reverse`(7)
-    /// [Supportability]: Windows, unknown
-    NoInverse = 27,
-    /// This will make the text visible.
-    /// [info]: Opposite of `Hidden`(8)
-    /// [Supportability]: Unknown
+    /// Turns off the `Reverse` attribute.
+    NoInverse = 27, // TODO Shouldn't we rename this to `NoReverse`? Or `Reverse` to `Inverse`?
+    /// Turns off the `Hidden` attribute.
     NoHidden = 28,
-    /// This will turn off the crossed out attribute.
-    /// [info]: Opposite of `CrossedOut`(9)
-    /// [Supportability]: Not widely supported
+    /// Turns off the `CrossedOut` attribute.
     NotCrossedOut = 29,
-    /// Framed text.
-    /// [Supportability]: Not widely supported
+    /// Makes the text framed.
     Framed = 51,
-    /// This will turn on the encircled attribute.
+    /// Makes the text encircled.
     Encircled = 52,
-    /// This will draw a line at the top of the text.
-    /// [info]: Implementation defined (according to standard)
-    /// [Supportability]: Unknown
+    /// Draws a line at the top of the text.
     OverLined = 53,
-    /// This will turn off the framed or encircled attribute.
+    /// Turns off the `Frame` and `Encircled` attributes.
     NotFramedOrEncircled = 54,
-    /// This will turn off the overLined attribute.
-    /// [info]: Opposite of `OverLined`(7)
-    /// [Supportability]: Windows, unknown
+    /// Turns off the `OverLined` attribute.
     NotOverLined = 55,
 
     #[doc(hidden)]

--- a/src/enums/attribute.rs
+++ b/src/enums/attribute.rs
@@ -14,7 +14,7 @@ use crate::SetAttr;
 /// * Crossterm implements almost all attributes listed in the
 ///   [SGR parameters](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters).
 ///
-/// | Attribute | Windows | Unix | Notes |
+/// | Attribute | Windows | UNIX | Notes |
 /// | :-- | :--: | :--: | :-- |
 /// | `Reset` | ✓ | ✓ | |
 /// | `Bold` | ✓ | ✓ | |

--- a/src/enums/color.rs
+++ b/src/enums/color.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 /// Represents a color.
 ///
-/// # Platform-specific notes
+/// # Platform-specific Notes
 ///
 /// The following list of 16 base colors are available for almost all terminals (Windows 7 and 8 included).
 ///

--- a/src/enums/color.rs
+++ b/src/enums/color.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 /// Represents a color.
 ///
-/// ## Platform-specific notes
+/// # Platform-specific notes
 ///
 /// The following list of 16 base colors are available for almost all terminals (Windows 7 and 8 included).
 ///

--- a/src/enums/color.rs
+++ b/src/enums/color.rs
@@ -4,45 +4,94 @@ use std::str::FromStr;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-/// Enum with the different colors to color your test and terminal.
+/// Represents a color.
+///
+/// ## Platform-specific notes
+///
+/// The following list of 16 base colors are available for almost all terminals (Windows 7 and 8 included).
+///
+/// | Light | Dark |
+/// | :--| :--   |
+/// | `Grey` | `Black` |
+/// | `Red` | `DarkRed` |
+/// | `Green` | `DarkGreen` |
+/// | `Yellow` | `DarkYellow` |
+/// | `Blue` | `DarkBlue` |
+/// | `Magenta` | `DarkMagenta` |
+/// | `Cyan` | `DarkCyan` |
+/// | `White` | `DarkWhite` |
+///
+/// Most UNIX terminals and Windows 10 consoles support additional colors.
+/// See [`Color::Rgb`](enum.Color.html#variant.Rgb) or [`Color::AnsiValue`](enum.Color.html#variant.AnsiValue) for
+/// more info.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub enum Color {
-    // This resets the color.
+    /// Resets the terminal color.
     Reset,
 
+    /// Black color.
     Black,
+
+    /// Dark grey color.
     DarkGrey,
 
+    /// Light red color.
     Red,
+
+    /// Dark red color.
     DarkRed,
 
+    /// Light green color.
     Green,
+
+    /// Dark green color.
     DarkGreen,
 
+    /// Light yellow color.
     Yellow,
+
+    /// Dark yellow color.
     DarkYellow,
 
+    /// Light blue color.
     Blue,
+
+    /// Dark blue color.
     DarkBlue,
 
+    /// Light magenta color.
     Magenta,
+
+    /// Dark magenta color.
     DarkMagenta,
 
+    /// Light cyan color.
     Cyan,
+
+    /// Dark cyan color.
     DarkCyan,
 
+    /// White color.
     White,
+
+    /// Grey color.
     Grey,
-    /// Color representing RGB-colors;
-    /// r = red
-    /// g = green
-    /// b = blue
+
+    /// An RGB color. See [RGB color model](https://en.wikipedia.org/wiki/RGB_color_model) for more info.
+    ///
+    /// Most UNIX terminals and Windows 10 supported only.
+    /// See [Platform-specific notes](enum.Color.html#platform-specific-notes) for more info.
     Rgb {
         r: u8,
         g: u8,
         b: u8,
     },
+
+    /// An ANSI color. See [256 colors - cheat sheet](https://jonasjacek.github.io/colors/) for more info.
+    ///
+    /// Most UNIX terminals and Windows 10 supported only.
+    /// See [Platform-specific notes](enum.Color.html#platform-specific-notes) for more info.
     AnsiValue(u8),
 }
 
@@ -51,10 +100,10 @@ impl FromStr for Color {
 
     /// Creates a `Color` from the string representation.
     ///
-    /// # Remarks
+    /// # Notes
     ///
-    /// * `Color::White` is returned in case of an unknown color.
-    /// * This function does not return `Err` and you can safely unwrap.
+    /// * Returns `Color::White` in case of an unknown color.
+    /// * Does not return `Err` and you can safely unwrap.
     fn from_str(src: &str) -> ::std::result::Result<Self, Self::Err> {
         let src = src.to_lowercase();
 

--- a/src/enums/color.rs
+++ b/src/enums/color.rs
@@ -82,11 +82,7 @@ pub enum Color {
     ///
     /// Most UNIX terminals and Windows 10 supported only.
     /// See [Platform-specific notes](enum.Color.html#platform-specific-notes) for more info.
-    Rgb {
-        r: u8,
-        g: u8,
-        b: u8,
-    },
+    Rgb { r: u8, g: u8, b: u8 },
 
     /// An ANSI color. See [256 colors - cheat sheet](https://jonasjacek.github.io/colors/) for more info.
     ///

--- a/src/enums/colored.rs
+++ b/src/enums/colored.rs
@@ -6,23 +6,26 @@ use serde::{Deserialize, Serialize};
 use crate::color;
 use crate::enums::Color;
 
-/// Can be used to easily change the front and back ground color
+/// Represents a foreground or a background color.
 ///
-/// # Example
+/// Can be used to easily change the text colors.
+///
+/// # Examples
 ///
 /// `Colored` implements `Display` therefore you can use it in any `write` operation.
 ///
 /// ```no_run
 /// use crossterm_style::{Colored, Color};
+///
 /// println!("{} Red foreground color", Colored::Fg(Color::Red));
 /// println!("{} Blue background color", Colored::Bg(Color::Blue));
 /// ```
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub enum Colored {
-    /// Use this if you want to change the foreground color
+    /// A foreground color.
     Fg(Color),
-    /// Use this if you want to change the background color
+    /// A background color.
     Bg(Color),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //! use std::io::{stdout, Write};
 //!
 //! use crossterm_utils::{execute, Result, Output};
-//! use crossterm_style::{SetBg, SetFg, SetAttr, Color, Attribute};
+//! use crossterm_style::{SetBg, SetFg, ResetColor, Color, Attribute};
 //!
 //! fn main() -> Result<()> {
 //!     execute!(
@@ -38,7 +38,7 @@
 //!         SetBg(Color::Red),
 //!         Output("Styled text here.".to_string()),
 //!         // Reset to default colors
-//!         SetAttr(Color::Reset)
+//!         ResetColor
 //!     )
 //! }
 //! ```
@@ -57,7 +57,7 @@
 //! ```no_run
 //! use crossterm_style::Colorize;
 //!
-//! println!("Red foreground color & blue background.".red().on_blue());
+//! println!("{}", "Red foreground color & blue background.".red().on_blue());
 //! ```
 //!
 //! ### Attributes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,7 +308,7 @@ pub fn color() -> TerminalColor {
 ///
 /// # Notes
 ///
-/// Commands must be executed / queued for execution otherwise they do nothing.
+/// Commands must be executed/queued for execution otherwise they do nothing.
 pub struct SetFg(pub Color);
 
 impl Command for SetFg {
@@ -330,7 +330,7 @@ impl Command for SetFg {
 ///
 /// # Notes
 ///
-/// Commands must be executed / queued for execution otherwise they do nothing.
+/// Commands must be executed/queued for execution otherwise they do nothing.
 pub struct SetBg(pub Color);
 
 impl Command for SetBg {
@@ -352,7 +352,7 @@ impl Command for SetBg {
 ///
 /// # Notes
 ///
-/// Commands must be executed / queued for execution otherwise they do nothing.
+/// Commands must be executed/queued for execution otherwise they do nothing.
 pub struct SetAttr(pub Attribute);
 
 impl Command for SetAttr {
@@ -375,7 +375,7 @@ impl Command for SetAttr {
 ///
 /// # Notes
 ///
-/// Commands must be executed / queued for execution otherwise they do nothing.
+/// Commands must be executed/queued for execution otherwise they do nothing.
 pub struct PrintStyledFont<D: Display + Clone>(pub StyledObject<D>);
 
 impl<D> Command for PrintStyledFont<D>
@@ -398,7 +398,7 @@ where
 ///
 /// # Notes
 ///
-/// Commands must be executed / queued for execution otherwise they do nothing.
+/// Commands must be executed/queued for execution otherwise they do nothing.
 pub struct ResetColor;
 
 impl Command for ResetColor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,156 +1,27 @@
-//! # Styling Module
+#![deny(unused_imports, unused_must_use)]
+
+//! # Style
 //!
-//! Crossterm provides options for you to style your text and terminal. Take for example coloring output and applying attributes.
+//! The `crossterm_style` crate provides a functionality to apply attributes and colors on your text.
 //!
-//! **Color support**
-//! Windows systems with versions less than 10 will only have support for 16 colors and don't have any support for attributes. Most UNIX-terminal is supporting lots of colors and attributes.
+//! This documentation does not contain a lot of examples. The reason is that it's fairly
+//! obvious how to use this crate. Although, we do provide
+//! [examples](https://github.com/crossterm-rs/examples) repository
+//! to demonstrate the capabilities.
 //!
-//! ## Colors
-//! There are 16 base colors which available for almost all terminals even windows 7 and 8.
+//! ## Platform-specific notes
 //!
-//! | Light Variant  | Dark Variant    |
-//! | :-------------| :-------------   |
-//! |       Grey     |      Black      |
-//! |       Red      |      DarkRed    |
-//! |       Green    |      DarkGreen  |
-//! |       Yellow   |      DarkYellow |
-//! |       Blue     |      DarkBlue   |
-//! |       Magenta  |      DarkMagenta|
-//! |       Cyan     |      DarkCyan   |
-//! |       White    |      DarkWhite  |
+//! Not all features are supported on all terminals / platforms. You should always consult
+//! platform-specific notes of the following types:
 //!
-//! In addition to 16 colors, most UNIX terminals and Windows 10 consoles are also supporting more colors.
-//! Those colors could be: [True color (24-bit)](https://en.wikipedia.org/wiki/Color_depth#True_color_(24-bit)) coloring scheme, which allows you to use [RGB](https://nl.wikipedia.org/wiki/RGB-kleursysteem), and [256 (Xterm, 8-bit)](https://jonasjacek.github.io/colors/) colors.
-//! Checkout the [examples](https://github.com/crossterm-rs/crossterm/blob/master/examples/style.rs) on how to use this feature.
+//! * [Color](enum.Color.html#platform-specific-notes)
+//! * [Attribute](enum.Attribute.html#platform-specific-notes)
 //!
-//! ## Attributes
-//! Only UNIX and Windows 10 terminals are supporting attributes on top of the text. Crossterm allows you to add attributes to the text.
-//! Not all attributes are widely supported for all terminals, keep that in mind when working with this.
+//! ## Examples
 //!
-//! Crossterm implements almost all attributes shown in this [Wikipedia-list](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters).
+//! ### Colors
 //!
-//! | Attribute                      |     Support                                             |  Note         |
-//! | :-------------:                |  :-------------:                                         | :-------------: |
-//! |       Reset                    |  Windows, UNIX                                           |  This will reset all current set attributes.     |
-//! |       Bold                     |  Windows, UNIX                                           |  This will increase the text sensitivity also known as bold.     |
-//! |       Dim                      |  Windows, UNIX                                           |  This will decrease the text sensitivity also known as bold.   |
-//! |       Italic                   |  Not widely supported, sometimes treated as inverse.     |  This will make the text italic.   |
-//! |       Underlined               |  Windows, UNIX                                           |  A line under a word, especially in order to show its importance.   |
-//! |       SlowBlink                |  Not widely supported, sometimes treated as inverse.     |  less than 150 per minute  |
-//! |       RapidBlink               |  Not widely supported                                    |  MS-DOS ANSI.SYS; 150+ per minute;  |
-//! |       Reverse                  |  Windows, UNIX                                           |   foreground and background colors |
-//! |       Hidden                   |  Windows, UNIX |                                         |  Also known as 'Conceal'
-//! |       Fraktur                  |  UNIX                                                    |  characters legible, but marked for deletion. |
-//! |       DefaultForegroundColor   |  Unknown                                                 |  Implementation defined (according to standard) |
-//! |       DefaultBackgroundColor   |  Unknown                                                 |  Implementation defined (according to standard) |
-//! |       Framed                   |  Not widely supported                                    |  Framed text.
-//! |       Encircled                |  Unknown                                                 |  This will turn on the encircled attribute. |
-//! |       OverLined                |  Unknown                                                 |  This will draw a line at the top of the text. |
-//!
-//! (There are a few attributes who disable one of the above attributes, I did not write those down to keep the list short).
-//!
-//! Now we have covered the basics of styling lets go over to some examples.
-//!
-//!
-//! # Example
-//!
-//! _setup the basics_
-//! ```no_run
-//! use crossterm_style::{Colored, Color, Attribute, Styler, Colorize};
-//!
-//! fn main() {
-//!     /* your code here */
-//! }
-//! ```
-//!
-//! There are a couple of ways to style the terminal output with crossterm. The most important part of the styling module is `StyledObject`.
-//!
-//! A `StyledObject` is just a wrapper crossterm uses to store the text and style together.
-//! A `StyledObject` implements `Display` and thus you could use it inside `print!`, `println!` etc.
-//!
-//! Without further ado let's get straight into it.
-//!
-//! ## Coloring
-//!
-//! There are a few ways to do the coloring, the first one is by using the `Colored` enum.
-//!
-//! ### Using Enum
-//! ```no_run
-//! use crossterm_style::{Colored, Color};
-//! println!("{} Red foreground color", Colored::Fg(Color::Red));
-//! println!("{} Blue background color", Colored::Bg(Color::Blue));
-//! ```
-//! `Colored::Bg` will set the background color, and `Colored::Fg` will set the foreground color to the provided color.
-//! The provided color is of type `Color` and has a bunch of enum values you could choose out.
-//!
-//! Because `Colored` implements `Display` you are able to use it inside any write statement.
-//!
-//! ### Using Methods
-//! You can do the same as the above in a slightly different way. Instead of enabling it for all text you could also color the only piece of text.
-//! (Make sure to include the `crossterm::Coloring` trait).
-//!
-//! ```no_run
-//! use crossterm_style::Colorize;
-//! let styled_text = "Red forground color on blue background.".red().on_blue();
-//! println!("{}", styled_text);
-//! ```
-//!
-//! As you see in the above example you could call coloring methods on a string. How is this possible you might ask..?
-//! Well, the trait `Coloring`, who you need to include, is implemented for `&'static str`.
-//! When calling a method on this string crossterm transforms it into a `StyledObject` who you could use in your write statements.
-//!
-//!
-//! ### RGB
-//! Most UNIX terminals and all Windows 10 consoles are supporting [True color(24-bit)](https://en.wikipedia.org/wiki/Color_depth#True_color_(24-bit)) coloring scheme.
-//! You can set the color of the terminal by using `Color::RGB(r,g,b)`.
-//!
-//! ```no_run
-//! // custom rgb value (Windows 10 and UNIX systems)
-//! use crossterm_style::{Colored, Color};
-//! println!("{}{} 'Light green' text on 'Black' background", Colored::Fg(Color::Rgb { r: 0, g: 255, b: 128 }), Colored::Bg(Color::Rgb {r: 0, g: 0, b: 0}));
-//! ```
-//! This will print some light green text on black background.
-//!
-//! ### Custom ANSI color value
-//! When working on UNIX or Windows 10 you could also specify a custom ANSI value ranging up from 0 to 256.
-//! See [256 (Xterm, 8-bit) colors](https://jonasjacek.github.io/colors/) for more information.
-//!
-//! ```
-//! // custom ansi color value (Windows 10 and UNIX systems)
-//! use crossterm_style::{Colored, Color};
-//! println!("{} some colored text", Colored::Fg(Color::AnsiValue(10)));
-//! ```
-//!
-//! ## Attributes
-//! When working with UNIX or Windows 10 terminals you could also use attributes to style your text. For example, you could cross your text with a line and make it bold.
-//! See [this](styling.md#Attributes) for more information.
-//!
-//! ### Using Enum
-//! You could use the `Attribute` enum for styling text with attributes.
-//! `Attribute` implements `Display`, thus crossterm will enable the attribute style when using it in any writing operation.
-//!
-//! ```rust
-//! use crossterm_style::Attribute;
-//! println!(
-//!     "{} Underlined {} No Underline",
-//!     Attribute::Underlined,
-//!     Attribute::NoUnderline
-//! );
-//! ```
-//!
-//! ### Using Method
-//!
-//! You can do the same as the above in a slightly different way. Instead of enabling it for all text you could also style only one piece of text.
-//! (Make sure to include the `crossterm::Styler` trait).
-//!
-//! ```no_run
-//! use crossterm_style::Styler;
-//! println!("{}", "Bold text".bold());
-//! println!("{}", "Underlined text".underlined());
-//! println!("{}", "Negative text".negative());
-//! ```
-//!
-//! ### Using Command API
+//! The command API:
 //!
 //! ```no_run
 //! use std::io::{stdout, Write};
@@ -161,28 +32,84 @@
 //! fn main() -> Result<()> {
 //!     execute!(
 //!         stdout(),
+//!         // Blue foreground
 //!         SetFg(Color::Blue),
+//!         // Red background
 //!         SetBg(Color::Red),
-//!         Output("Blue text on red background".to_string()),
+//!         Output("Styled text here.".to_string()),
+//!         // Reset to default colors
+//!         SetAttr(Color::Reset)
+//!     )
+//! }
+//! ```
+//!
+//! The [`Colored`](enum.Colored.html) & [`Color`](enum.Color.html) enums:
+//!
+//! ```no_run
+//! use crossterm_style::{Colored, Color};
+//!
+//! println!("{} Red foreground", Colored::Fg(Color::Red));
+//! println!("{} Blue background", Colored::Bg(Color::Blue));
+//! ```
+//!
+//! The [`Colorize`](trait.Colorize.html) trait:
+//!
+//! ```no_run
+//! use crossterm_style::Colorize;
+//!
+//! println!("Red foreground color & blue background.".red().on_blue());
+//! ```
+//!
+//! ### Attributes
+//!
+//! The command API:
+//!
+//! ```no_run
+//! use std::io::{stdout, Write};
+//!
+//! use crossterm_utils::{execute, Result, Output};
+//! use crossterm_style::{SetAttr, Attribute};
+//!
+//! fn main() -> Result<()> {
+//!     execute!(
+//!         stdout(),
+//!         // Set to bold
+//!         SetAttr(Attribute::Bold),
+//!         Output("Styled text here.".to_string()),
+//!         // Reset all attributes
 //!         SetAttr(Attribute::Reset)
 //!     )
 //! }
 //! ```
 //!
-//! As you see in the above example you could call attributes methods on a string. How is this possible you might ask..?
-//! Well, the trait `Styling`, who you need to include, is implemented for `&'static str`.
-//! When calling a method on any string crossterm transforms will transform it into a `StyledObject` who you could use in your write statements.
+//! The [`Styler`](trait.Styler.html) trait:
 //!
-//! ---------------------------------------------------------------------------------------------------------------------------------------------
-//! More examples could be found at this [link](https://github.com/crossterm-rs/crossterm/blob/master/examples/style.rs).
-
-#![deny(unused_imports)]
+//! ```no_run
+//! use crossterm_style::Styler;
+//!
+//! println!("{}", "Bold".bold());
+//! println!("{}", "Underlined".underlined());
+//! println!("{}", "Negative".negative());
+//! ```
+//!
+//! The [`Attribute`](enum.Attribute.html) enum:
+//!
+//! ```no_run
+//! use crossterm_style::Attribute;
+//!
+//! println!(
+//!     "{} Underlined {} No Underline",
+//!     Attribute::Underlined,
+//!     Attribute::NoUnderline
+//! );
+//! ```
 
 use std::env;
 use std::fmt::Display;
 
 #[cfg(windows)]
 use crossterm_utils::supports_ansi;
+#[doc(no_inline)]
 pub use crossterm_utils::{
     execute, impl_display, queue, Command, ExecutableCommand, QueueableCommand, Result,
 };
@@ -205,22 +132,22 @@ mod style;
 mod styledobject;
 mod traits;
 
-/// This could be used to style a type that implements `Display` with colors and attributes.
+/// Creates a `StyledObject`.
 ///
-/// # Example
+/// This could be used to style any type that implements `Display` with colors and text attributes.
+///
+/// See [`StyledObject`](struct.StyledObject.html) for more info.
+///
+/// # Examples
+///
 /// ```no_run
-/// // get a styled object which could be painted to the terminal.
 /// use crossterm_style::{style, Color};
 ///
-/// let styled_object = style("Some Blue colored text on black background")
+/// let styled_object = style("Blue colored text on yellow background")
 ///     .with(Color::Blue)
-///     .on(Color::Black);
+///     .on(Color::Yellow);
 ///
-/// // print the styled text 10 * times to the current screen.
-/// for i in 1..10
-/// {
-///     println!("{}", styled_object);
-/// }
+/// println!("{}", styled_object);
 /// ```
 pub fn style<'a, D: 'a>(val: D) -> StyledObject<D>
 where
@@ -281,19 +208,9 @@ impl Styler<&'static str> for &'static str {
     def_str_attr!(crossed_out => Attribute::CrossedOut);
 }
 
-/// Allows you to style the terminal.
+/// A terminal color.
 ///
-/// # Features:
-///
-/// - Foreground color (16 base colors)
-/// - Background color (16 base colors)
-/// - 256 color support (Windows 10 and UNIX only)
-/// - RGB support (Windows 10 and UNIX only)
-/// - Text Attributes like: bold, italic, underscore and crossed word ect (Windows 10 and UNIX only)
-///
-/// Check [examples](https://github.com/crossterm-rs/examples) in the library for more specific examples.
-///
-/// ## Examples
+/// # Examples
 ///
 /// Basic usage:
 ///
@@ -304,11 +221,11 @@ impl Styler<&'static str> for &'static str {
 ///
 /// fn main() -> Result<()> {
 ///     let color = TerminalColor::new();
-///     // set foreground color
+///     // Set foreground color
 ///     color.set_fg(Color::Blue)?;
-///     // set background color
+///     // Set background color
 ///     color.set_bg(Color::Red)?;
-///     // reset to the default colors
+///     // Reset to the default colors
 ///     color.reset()
 /// }
 /// ```
@@ -320,7 +237,7 @@ pub struct TerminalColor {
 }
 
 impl TerminalColor {
-    /// Creates a new `TerminalColor`
+    /// Creates a new `TerminalColor`.
     pub fn new() -> TerminalColor {
         #[cfg(windows)]
         let color = if supports_ansi() {
@@ -335,24 +252,24 @@ impl TerminalColor {
         TerminalColor { color }
     }
 
-    /// Set the foreground color to the given color.
+    /// Sets the foreground color.
     pub fn set_fg(&self, color: Color) -> Result<()> {
         self.color.set_fg(color)
     }
 
-    /// Set the background color to the given color.
+    /// Sets the background color.
     pub fn set_bg(&self, color: Color) -> Result<()> {
         self.color.set_bg(color)
     }
 
-    /// Reset the terminal colors and attributes to default.
+    /// Resets the terminal colors and attributes to the default ones.
     pub fn reset(&self) -> Result<()> {
         self.color.reset()
     }
 
-    /// Get available color count.
+    /// Gets available color count.
     ///
-    /// # Remarks
+    /// # Notes
     ///
     /// This does not always provide a good result.
     pub fn available_color_count(&self) -> u16 {
@@ -362,14 +279,36 @@ impl TerminalColor {
     }
 }
 
-/// Get a `TerminalColor` implementation whereon color related actions can be performed.
+/// Creates a new `TerminalColor`.
+///
+/// # Examples
+///
+/// Basic usage:
+///
+/// ```no_run
+/// use crossterm_style::{color, Color, Result};
+///
+/// fn main() -> Result<()> {
+///     let color = color();
+///     // Set foreground color
+///     color.set_fg(Color::Blue)?;
+///     // Set background color
+///     color.set_bg(Color::Red)?;
+///     // Reset to the default colors
+///     color.reset()
+/// }
+/// ```
 pub fn color() -> TerminalColor {
     TerminalColor::new()
 }
 
-/// When executed, this command will set the foreground color of the terminal to the given color.
+/// A command to set the foreground color.
 ///
-/// See `crossterm/examples/command.rs` for more information on how to execute commands.
+/// See [`Color`](enum.Color.html) for more info.
+///
+/// # Notes
+///
+/// Commands must be executed / queued for execution otherwise they do nothing.
 pub struct SetFg(pub Color);
 
 impl Command for SetFg {
@@ -385,9 +324,13 @@ impl Command for SetFg {
     }
 }
 
-/// When executed, this command will set the background color of the terminal to the given color.
+/// A command to set the background color.
 ///
-/// See `crossterm/examples/command.rs` for more information on how to execute commands.
+/// See [`Color`](enum.Color.html) for more info.
+///
+/// # Notes
+///
+/// Commands must be executed / queued for execution otherwise they do nothing.
 pub struct SetBg(pub Color);
 
 impl Command for SetBg {
@@ -403,9 +346,13 @@ impl Command for SetBg {
     }
 }
 
-/// When executed, this command will set the given attribute to the terminal.
+/// A command to set the text attribute.
 ///
-/// See `crossterm/examples/command.rs` for more information on how to execute commands.
+/// See [`Attribute`](enum.Attribute.html) for more info.
+///
+/// # Notes
+///
+/// Commands must be executed / queued for execution otherwise they do nothing.
 pub struct SetAttr(pub Attribute);
 
 impl Command for SetAttr {
@@ -422,9 +369,13 @@ impl Command for SetAttr {
     }
 }
 
-/// When executed, this command will print the styled font to the terminal.
+/// A command to print the styled object.
 ///
-/// See `crossterm/examples/command.rs` for more information on how to execute commands.
+/// See [`StyledObject`](struct.StyledObject.html) for more info.
+///
+/// # Notes
+///
+/// Commands must be executed / queued for execution otherwise they do nothing.
 pub struct PrintStyledFont<D: Display + Clone>(pub StyledObject<D>);
 
 impl<D> Command for PrintStyledFont<D>
@@ -443,9 +394,11 @@ where
     }
 }
 
-/// When executed, this command will reset the console colors back to default
+/// A command to reset the colors back to default ones.
 ///
-/// See `crossterm/examples/command.rs` for more information on how to execute commands.
+/// # Notes
+///
+/// Commands must be executed / queued for execution otherwise they do nothing.
 pub struct ResetColor;
 
 impl Command for ResetColor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! ## Platform-specific Notes
 //!
-//! Not all features are supported on all terminals / platforms. You should always consult
+//! Not all features are supported on all terminals/platforms. You should always consult
 //! platform-specific notes of the following types:
 //!
 //! * [Color](enum.Color.html#platform-specific-notes)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,7 @@ impl TerminalColor {
         self.color.reset()
     }
 
-    /// Gets available color count.
+    /// Returns available color count.
     ///
     /// # Notes
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! [examples](https://github.com/crossterm-rs/examples) repository
 //! to demonstrate the capabilities.
 //!
-//! ## Platform-specific notes
+//! ## Platform-specific Notes
 //!
 //! Not all features are supported on all terminals / platforms. You should always consult
 //! platform-specific notes of the following types:

--- a/src/objectstyle.rs
+++ b/src/objectstyle.rs
@@ -11,7 +11,7 @@ pub struct ObjectStyle {
     pub fg_color: Option<Color>,
     /// The background color.
     pub bg_color: Option<Color>,
-    /// List of text attributes.
+    /// List of attributes.
     pub attrs: Vec<Attribute>,
 }
 
@@ -41,7 +41,9 @@ impl ObjectStyle {
         self
     }
 
-    /// Adds the text attribute.
+    /// Adds the attribute.
+    ///
+    /// You can add more attributes by calling this method multiple times.
     pub fn add_attr(&mut self, attr: Attribute) {
         self.attrs.push(attr);
     }

--- a/src/objectstyle.rs
+++ b/src/objectstyle.rs
@@ -4,16 +4,19 @@ use std::fmt::Display;
 
 use super::{Attribute, Color, StyledObject};
 
-/// Struct that contains the style properties that can be applied to a displayable object.
+/// An object style.
 #[derive(Debug, Clone, Default)]
 pub struct ObjectStyle {
+    /// The foreground color.
     pub fg_color: Option<Color>,
+    /// The background color.
     pub bg_color: Option<Color>,
+    /// List of text attributes.
     pub attrs: Vec<Attribute>,
 }
 
 impl ObjectStyle {
-    /// Apply a `StyledObject` to the passed displayable object.
+    /// Creates a `StyledObject` by applying the style to the given `val`.
     pub fn apply_to<D: Display + Clone>(&self, val: D) -> StyledObject<D> {
         StyledObject {
             object_style: self.clone(),
@@ -21,24 +24,24 @@ impl ObjectStyle {
         }
     }
 
-    /// Get a new instance of `ObjectStyle`
+    /// Creates a new `ObjectStyle`.
     pub fn new() -> ObjectStyle {
         ObjectStyle::default()
     }
 
-    /// Set the background color of `ObjectStyle` to the passed color.
+    /// Sets the background color.
     pub fn bg(mut self, color: Color) -> ObjectStyle {
         self.bg_color = Some(color);
         self
     }
 
-    /// Set the foreground color of `ObjectStyle` to the passed color.
+    /// Sets the foreground color.
     pub fn fg(mut self, color: Color) -> ObjectStyle {
         self.fg_color = Some(color);
         self
     }
 
-    /// Add an `Attribute` to the current text. Like italic or bold.
+    /// Adds the text attribute.
     pub fn add_attr(&mut self, attr: Attribute) {
         self.attrs.push(attr);
     }

--- a/src/styledobject.rs
+++ b/src/styledobject.rs
@@ -7,39 +7,42 @@ use crossterm_utils::queue;
 
 use crate::{Attribute, Color, Colorize, ObjectStyle, ResetColor, SetAttr, SetBg, SetFg, Styler};
 
-/// Contains both the style and the content which can be styled.
+/// A styled object.
+///
+/// # Examples
+///
+/// ```rust
+/// use crossterm_style::{style, Color, Attribute};
+///
+/// let styled = style("Hello there")
+///     .with(Color::Yellow)
+///     .on(Color::Blue)
+///     .attr(Attribute::Bold);
+///
+/// println!("{}", styled);
+/// ```
 #[derive(Clone)]
 pub struct StyledObject<D: Display + Clone> {
+    /// The object style (colors, text attributes).
     pub object_style: ObjectStyle,
+    /// An object to apply the style on.
     pub content: D,
 }
 
 impl<'a, D: Display + 'a + Clone> StyledObject<D> {
-    /// Set the foreground color with the given color
-    ///
-    /// # Remarks
-    ///
-    /// This methods consumes 'self', and works like a builder, like: `with().on().attr()`.
+    /// Sets the foreground color.
     pub fn with(mut self, foreground_color: Color) -> StyledObject<D> {
         self.object_style = self.object_style.fg(foreground_color);
         self
     }
 
-    /// Set the background color with the given color
-    ///
-    /// # Remarks
-    ///
-    /// This methods consumes 'self', and works like a builder, like: `with().on().attr()`.
+    /// Sets the background color.
     pub fn on(mut self, background_color: Color) -> StyledObject<D> {
         self.object_style = self.object_style.bg(background_color);
         self
     }
 
-    /// Add an attribute to the styled object.
-    ///
-    /// # Remarks
-    ///
-    /// This methods consumes 'self', and works like a builder, like: `with().on().attr()`.
+    /// Sets the text attribute.
     pub fn attr(mut self, attr: Attribute) -> StyledObject<D> {
         self.object_style.add_attr(attr);
         self

--- a/src/styledobject.rs
+++ b/src/styledobject.rs
@@ -23,7 +23,7 @@ use crate::{Attribute, Color, Colorize, ObjectStyle, ResetColor, SetAttr, SetBg,
 /// ```
 #[derive(Clone)]
 pub struct StyledObject<D: Display + Clone> {
-    /// The object style (colors, text attributes).
+    /// The object style (colors, content attributes).
     pub object_style: ObjectStyle,
     /// An object to apply the style on.
     pub content: D,

--- a/src/styledobject.rs
+++ b/src/styledobject.rs
@@ -42,7 +42,9 @@ impl<'a, D: Display + 'a + Clone> StyledObject<D> {
         self
     }
 
-    /// Sets the text attribute.
+    /// Adds the attribute.
+    ///
+    /// You can add more attributes by calling this method multiple times.
     pub fn attr(mut self, attr: Attribute) -> StyledObject<D> {
         self.object_style.add_attr(attr);
         self

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -2,11 +2,14 @@ use std::fmt::Display;
 
 use crate::StyledObject;
 
-/// Provides a set of methods to color any type implementing `Display` + `Clone`.
+/// Provides a set of methods to set the colors.
 ///
-/// This trait is implemented for `&static str` and `StyledObject`, you can invoke these methods there.
+/// Every method with the `on_` prefix sets the background color. All other methods set
+/// the foreground color.
 ///
-/// # Example
+/// Method names correspond to the [`Color`](enum.Color.html) enum variants.
+///
+/// # Examples
 ///
 /// ```no_run
 /// use crossterm_style::Colorize;
@@ -50,11 +53,11 @@ pub trait Colorize<D: Display + Clone> {
     fn on_grey(self) -> StyledObject<D>;
 }
 
-/// Provides a set of methods to style any type implementing `Display` with attributes.
+/// Provides a set of methods to set the text attributes.
 ///
-/// This trait is implemented for `&static str` and `StyledObject`, you can invoke these methods there.
+/// Method names correspond to the [`Attribute`](enum.Attribute.html) enum variants.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```no_run
 /// use crossterm_style::Styler;


### PR DESCRIPTION
Same documentation style as `-cursor` & `-terminal`.

* Read the README here - https://github.com/crossterm-rs/crossterm-style/blob/zrzka/sync-documentation-style/README.md
* Read the docs via `cargo doc --open`