### PR TITLE
Swapped INTENSITY

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,7 @@ impl TerminalColor {
     pub fn new() -> TerminalColor {
         #[cfg(windows)]
         let color = if supports_ansi() {
-            Box::from(AnsiColor::new()) as Box<(dyn Style + Sync + Send)>;
+            Box::from(AnsiColor::new()) as Box<(dyn Style + Sync + Send)>
         } else {
             WinApiColor::new() as Box<(dyn Style + Sync + Send)>
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,8 @@ impl TerminalColor {
     pub fn new() -> TerminalColor {
         #[cfg(windows)]
         let color = if supports_ansi() {
-            Box::from(AnsiColor::new()) as Box<(dyn Style + Sync + Send)>
+           let a= Box::from(AnsiColor::new()) as Box<(dyn Style + Sync + Send)>;
+            WinApiColor::new() as Box<(dyn Style + Sync + Send)>
         } else {
             WinApiColor::new() as Box<(dyn Style + Sync + Send)>
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,8 +241,7 @@ impl TerminalColor {
     pub fn new() -> TerminalColor {
         #[cfg(windows)]
         let color = if supports_ansi() {
-           let a= Box::from(AnsiColor::new()) as Box<(dyn Style + Sync + Send)>;
-            WinApiColor::new() as Box<(dyn Style + Sync + Send)>
+            Box::from(AnsiColor::new()) as Box<(dyn Style + Sync + Send)>;
         } else {
             WinApiColor::new() as Box<(dyn Style + Sync + Send)>
         };

--- a/src/style/winapi.rs
+++ b/src/style/winapi.rs
@@ -111,8 +111,8 @@ impl From<Colored> for u16 {
                     Color::DarkMagenta => FG_RED | FG_BLUE,
                     Color::Cyan => FG_INTENSITY | FG_GREEN | FG_BLUE,
                     Color::DarkCyan => FG_GREEN | FG_BLUE,
-                    Color::White => FG_RED | FG_GREEN | FG_BLUE,
-                    Color::Grey => FG_INTENSITY | FG_RED | FG_GREEN | FG_BLUE,
+                    Color::White => FG_INTENSITY | FG_RED | FG_GREEN | FG_BLUE,
+                    Color::Grey => FG_RED | FG_GREEN | FG_BLUE,
 
                     Color::Reset => {
                         // safe unwrap, initial console color was set with `init_console_color`.

--- a/src/style/winapi.rs
+++ b/src/style/winapi.rs
@@ -27,7 +27,6 @@ pub(crate) struct WinApiColor;
 impl WinApiColor {
     pub fn new() -> Box<WinApiColor> {
         init_console_color().unwrap();
-
         Box::from(WinApiColor)
     }
 }


### PR DESCRIPTION
Removed INTENSITY from foreground color grey and added it to white. 

Fixes: https://github.com/crossterm-rs/crossterm/issues/263


Powershell WinApi windows 10

![image](https://user-images.githubusercontent.com/19969910/66404530-eda1d000-e9e8-11e9-989c-833592647316.png)

CMD WinApi windows 10 

![image](https://user-images.githubusercontent.com/19969910/66405956-26db3f80-e9eb-11e9-8fe7-02b7ed784888.png)



Windows 7 WinApi

![image](https://user-images.githubusercontent.com/19969910/66405326-41f97f80-e9ea-11e9-8b32-01ae2f82bf82.png)